### PR TITLE
feat: Base styles (spacing)

### DIFF
--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -1,29 +1,3 @@
 @import "./settings/colors";
+@import "./settings/spacing";
 @import "./tools/functions";
-
-html,
-body {
-  padding: 0;
-  margin: 0;
-  font-family:
-    -apple-system,
-    BlinkMacSystemFont,
-    "Segoe UI",
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    "Fira Sans",
-    "Droid Sans",
-    "Helvetica Neue",
-    sans-serif;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-* {
-  box-sizing: border-box;
-}

--- a/styles/settings/_spacing.scss
+++ b/styles/settings/_spacing.scss
@@ -1,0 +1,12 @@
+$spacer: (
+  "2xs": 0.25rem,  // 4px
+  "xs": 0.5rem,  // 8px
+  "sm": 1rem,  // 16px
+  "md": 1.5rem,  // 24px
+  "lg": 2rem,  // 32px
+  "xl": 2.63rem,  // 42px
+  "2xl": 3rem,  // 48px
+  "3xl": 4rem,  // 64px
+  "detail-header-to-content": 5.63rem,  // 90px
+  "navbar-to-header": 8.5rem,  // 136px
+);

--- a/styles/tools/_functions.scss
+++ b/styles/tools/_functions.scss
@@ -10,6 +10,10 @@
   @return map-get($font-families, stringify($key));
 }
 
+@function space($key) {
+  @return map-get($spacer, stringify($key));
+}
+
 @function stringify($value) {
   @return $value + "";
 }

--- a/styles/tools/functions.test.js
+++ b/styles/tools/functions.test.js
@@ -6,4 +6,4 @@ import { join } from 'path';
 import { runSass } from 'sass-true';
 
 const sassFile = join(__dirname, 'functions_test.scss');
-runSass({file: sassFile}, {describe, it});
+runSass({ file: sassFile }, { describe, it });

--- a/styles/tools/functions_test.scss
+++ b/styles/tools/functions_test.scss
@@ -1,8 +1,9 @@
 @import "node_modules/sass-true/sass/true";
-@import "./functions";
 @import "./../settings/colors";
 @import "./../settings/font-families";
 @import "./../settings/font-sizes";
+@import "./../settings/spacing";
+@import "./functions";
 
 @include describe("color function") {
   @include it("returns hex value from colors scss map") {
@@ -12,15 +13,24 @@
 
 @include describe("font-size function") {
   @include it("returns rem value from font-size scss map") {
-    @include assert-equal(font-size(sm),
-    1.063rem);
+    @include assert-equal(font-size(sm), 1.063rem);
   }
 }
 
 @include describe("font-families function") {
   @include it("returns list of fonts from font-families scss map") {
-    @include assert-equal(font-family("mono"),
-    (menlo, consolas, monaco)
-  );
+    @include assert-equal(font-family("mono"), (menlo, consolas, monaco));
+  }
+}
+
+@include describe("space function") {
+  @include it("returns correct size in rem from spacing SCSS map") {
+    @include assert-equal(space("lg"), 2rem);
+  }
+}
+
+@include describe("stringify function") {
+  @include it("converts input to a string") {
+    @include assert-equal(stringify(6), "6");
   }
 }


### PR DESCRIPTION
### Description
- Create spacing SCSS map
- Import `_spacing.scss` into `globals.scss`
- Add `space` function to simplify usage of spacing map
  - Test for `space` function behavior

### Spec

Designs: [Designs](https://www.figma.com/file/kswpPSHH2h5njVyfGDbIHk/FSA-Capstone-Project-2022?node-id=0%3A1)

See Story: [166]((https://sparkbox.atlassian.net/browse/FSA22V1-166))

### Validation
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR has new SCSS functions, mixins, or variables, so [Sass Tests](https://seesparkbox.com/foundry/how_and_why_we_unit_test_our_sass) were added or updated, and they pass.

#### To Validate
1. Pull down `feat--base-styles-spacing` branch.
2. Run `npm install`.
3. Run `npm run lint` and verify no linting errors.
4. Run `npm run test` and verify all tests pass.
