### PR TITLE
feat: setup custom 404 page

### DIFF
--- a/__tests__/404.test.jsx
+++ b/__tests__/404.test.jsx
@@ -1,0 +1,12 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import PageNotFound from '../pages/404';
+
+describe('PageNotFound', () => {
+  it('renders the expected text', async () => {
+    render(<PageNotFound />);
+
+    await waitFor(() => expect(screen.getByText('404')).toBeInTheDocument());
+  });
+});

--- a/__tests__/[id].test.jsx
+++ b/__tests__/[id].test.jsx
@@ -1,31 +1,51 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom/extend-expect';
-import { useRouter } from 'next/router';
 
-import DetailPage from '../pages/[id]';
+import apiService from '../services/apiService';
+import DetailPage, { getServerSideProps } from '../pages/[id]';
 
-jest.mock('next/router');
+const MOCK_TEAM_MEMBER = {
+  firstName: 'Aragorn II',
+  lastName: 'Elessar',
+};
+
+jest.mock('../services/apiService');
+
+apiService.getTeamMemberById = jest.fn(() => Promise.resolve(MOCK_TEAM_MEMBER));
 
 describe('DetailPage', () => {
-  const MOCK_TEAM_MEMBER = {
-    '0001': { firstName: 'Aragorn II', lastName: 'Elessar' },
-  };
-
-  useRouter.mockImplementation(() => (
-    {
-      query: { id: '0001' },
-    }
-  ));
-
-  global.fetch = jest.fn(() => (
-    Promise.resolve({
-      json: () => Promise.resolve(MOCK_TEAM_MEMBER),
-    })
-  ));
-
-  it('renders the expected test', async () => {
-    render(<DetailPage />);
+  it('renders the expected text', async () => {
+    render(
+      <DetailPage fetchedTeamMember={MOCK_TEAM_MEMBER} />,
+    );
 
     await waitFor(() => expect(screen.getByText('Greetings Aragorn II Elessar!')).toBeInTheDocument());
+  });
+});
+
+describe('getServerSideProps', () => {
+  it('calls getMemberById', async () => {
+    const context = {
+      params: {
+        id: '0001',
+      },
+      req: {
+        headers: {
+          host: 'localhost:3000',
+        },
+      },
+    };
+    const response = await getServerSideProps(context);
+
+    expect(response).toEqual(
+      expect.objectContaining({
+        props: {
+          fetchedTeamMember: {
+            firstName: 'Aragorn II',
+            lastName: 'Elessar',
+          },
+        },
+      }),
+    );
   });
 });

--- a/pages/404.jsx
+++ b/pages/404.jsx
@@ -1,0 +1,50 @@
+import Head from 'next/head';
+import Link from 'next/link';
+
+export default function PageNotFound() {
+  return (
+    <div>
+      <Head>
+        <title>Page Not Found</title>
+      </Head>
+
+      <main>
+        <h1>404</h1>
+
+        <p>
+          Hail, traveler. There is nothing to be found here.
+        </p>
+        <p>
+          But since we should reward ardent exploration, here is a poem for you.
+        </p>
+
+        <figure>
+          <h2>The Road Goes Ever On</h2>
+
+          <blockquote>
+            <p>The Road goes ever on and on</p>
+            <p>Down from the door where it began.</p>
+            <p>Now far ahead the Road has gone,</p>
+            <p>And I must follow, if I can,</p>
+            <p>Pursuing it with eager feet,</p>
+            <p>Until it joins some larger way</p>
+            <p>Where many paths and errands meet.</p>
+            <p>And whither then? I cannot say.</p>
+          </blockquote>
+
+          <figcaption>
+            From
+            {' '}
+            <cite>
+              The Hobbit
+            </cite>
+            {' '}
+            by J.R.R. Tolkien.
+          </figcaption>
+        </figure>
+
+        <Link href="/">&lt; Return whence you came.</Link>
+      </main>
+    </div>
+  );
+}

--- a/pages/[id].jsx
+++ b/pages/[id].jsx
@@ -1,58 +1,46 @@
-import { useEffect, useState } from 'react';
-import { useRouter } from 'next/router';
 import Head from 'next/head';
 
 import apiService from '../services/apiService';
-import LoadingStatus, { loadingStates } from '../components/LoadingStatus';
 
-export default function DetailPage() {
-  const [teamMemberDetails, setTeamMemberDetails] = useState({});
-  const [loadingStatus, setLoadingStatus] = useState(loadingStates.EMPTY);
-  const router = useRouter();
-  const { id } = router.query;
-
-  useEffect(() => {
-    const getAndSetData = async () => {
-      try {
-        setLoadingStatus(loadingStates.LOADING);
-        const fetchedTeamMember = await apiService.getTeamMemberById('api/fellowship/', id);
-        setTeamMemberDetails(fetchedTeamMember);
-        setLoadingStatus(loadingStates.LOADED);
-      } catch (err) {
-        setLoadingStatus(loadingStates.ERROR);
-      }
-    };
-
-    if (id) getAndSetData();
-  }, [id]);
-
+export default function DetailPage({ fetchedTeamMember }) {
   return (
     <div>
       <Head>
         <title>
-          {teamMemberDetails && teamMemberDetails.firstName}
+          {fetchedTeamMember.firstName}
           {' '}
           | Sparkbox Team Availability
         </title>
-        <meta name="description" content={`View details about ${teamMemberDetails && teamMemberDetails.firstName}, including their projects, skills, and interests.`} />
+        <meta name="description" content={`View details about ${fetchedTeamMember && fetchedTeamMember.firstName}, including their projects, skills, and interests.`} />
       </Head>
       <main>
-
-        <LoadingStatus
-          loadingStatus={loadingStatus}
-        />
-
-        {loadingStatus === loadingStates.LOADED && (
-          <h1>
-            Greetings
-            {' '}
-            {teamMemberDetails.firstName}
-            {teamMemberDetails.lastName && ` ${teamMemberDetails.lastName}`}
-            !
-          </h1>
-        )}
-
+        <h1>
+          Greetings
+          {' '}
+          {fetchedTeamMember.firstName}
+          {fetchedTeamMember.lastName && ` ${fetchedTeamMember.lastName}`}
+          !
+        </h1>
       </main>
     </div>
   );
+}
+
+export async function getServerSideProps({ params, req }) {
+  const { id } = params;
+  const { host } = req.headers;
+  const baseUrl = `http://${host}/api/fellowship/`;
+  const fetchedTeamMember = await apiService.getTeamMemberById(baseUrl, id);
+
+  if (!fetchedTeamMember) {
+    return {
+      notFound: true,
+    };
+  }
+
+  return {
+    props: {
+      fetchedTeamMember,
+    },
+  };
 }


### PR DESCRIPTION
### Description
- Setup custom 404 page
- `[id].jsx` redirects to 404 page if team member not found
  - Use `getServerSideProps` function to pre-render page
- Update `[id].test.jsx` to reflect changes in DetailPage
- Test PageNotFound component

### Spec
See Story: [173](https://sparkbox.atlassian.net/browse/FSA22V1-173)

### Validation
* [ ] This PR has code changes, and our linters still pass.
* [ ] This PR affects production code, so it was browser tested.
* [ ] This PR has new code, so new tests were added or updated, and they pass.

#### To Validate
1. Pull down `feat--custom-404-page` branch.
2. Run `npm install`.
3. Run `npm run lint` and verify no linting errors.
4. Run `npm run test` and verify all tests pass.
5. Run `npm run dev`.
6. Navigate to `localhost:3000/bad/url` and verify redirection to 404 page.
7. Navigate to `localhost:3000/bad-url` and verify redirection to 404 page.