### PR TITLE
feat: linearly scale trading cards sizing

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -9,7 +9,10 @@
           "color",
           "font-family",
           "font-size",
-          "space"
+          "space",
+          "math.div",
+          "strip-units",
+          "linear-scale"
         ]
       }
     ]

--- a/components/HoursBar.jsx
+++ b/components/HoursBar.jsx
@@ -1,13 +1,18 @@
+import { useFilterContext } from '../context/FilterContext';
 import getClassColorModifierString from '../util/getClassColorModifierString';
+import getForecastedHoursIdx from '../util/getForecastedHoursIdx';
 
 export default function HoursBar({ forecastedHours, weeklyCapacity }) {
+  const { weekOffset } = useFilterContext();
+  const idx = getForecastedHoursIdx(weekOffset);
+
   const fillRatioStyles = ({
-    '--fill-ratio': `${((weeklyCapacity - forecastedHours) / weeklyCapacity)}`,
+    '--fill-ratio': `${((weeklyCapacity - forecastedHours[idx]) / weeklyCapacity)}`,
   });
 
   return (
     <div className="cmp-hours-bar">
-      <div style={fillRatioStyles} className={`cmp-hours-bar__fill  cmp-hours-bar__fill--fill-${getClassColorModifierString(weeklyCapacity, forecastedHours)}`} />
+      <div style={fillRatioStyles} className={`cmp-hours-bar__fill  cmp-hours-bar__fill--fill-${getClassColorModifierString(weeklyCapacity, forecastedHours[idx])}`} />
     </div>
   );
 }

--- a/components/TradingCardImage.jsx
+++ b/components/TradingCardImage.jsx
@@ -14,6 +14,7 @@ export default function TradingCardImage({ imageUrl, weeklyCapacity, forecastedH
         <div className={`cmp-trading-card-image__image cmp-trading-card-image__image--${classColorModifier}`}>
           <Image
             src={imageUrl}
+            loading="lazy"
             layout="responsive"
             width={350}
             height={350}

--- a/styles/components/_trading-card-grid.scss
+++ b/styles/components/_trading-card-grid.scss
@@ -1,9 +1,31 @@
 .cmp-trading-card-grid {
   width: 100%;
+
+  $grid-col-width: linear-scale(
+    $min-trading-card-width,
+    $max-trading-card-width,
+    $xs-screen-width,
+    $lg-screen-width
+  );
+
   margin: 0 auto;
   display: grid;
   align-items: start;
   justify-content: space-around;
-  grid-template-columns: repeat(auto-fill, $trading-card-width);
-  gap: space("xl") space("md");
+  grid-template-columns: repeat(auto-fill, $grid-col-width);
+
+  $column-gap: linear-scale(
+    space("xs"),
+    space("md"),
+    $xs-screen-width,
+    $lg-screen-width
+  );
+  $row-gap: linear-scale(
+    space("sm"),
+    space("xl"),
+    $xs-screen-width,
+    $lg-screen-width
+  );
+
+  gap: $row-gap $column-gap;
 }

--- a/styles/components/_trading-card-image.scss
+++ b/styles/components/_trading-card-image.scss
@@ -1,9 +1,15 @@
 .cmp-trading-card-image {
-  $image-size: $trading-card-width;
+  $image-size: $max-trading-card-width;
 
   order: 1;
   position: relative;
-  width: clamp(9rem, 100%, 18rem);
+  width:
+    linear-scale(
+      $min-trading-card-width,
+      $max-trading-card-width,
+      $xs-screen-width,
+      $lg-screen-width
+    );
 
   &__overlay {
     position: relative;
@@ -92,8 +98,20 @@
     align-items: center;
     justify-content: center;
     border-radius: 50%;
-    width: calc($image-size * 0.24);
-    height: calc($image-size * 0.24);
+    width:
+      linear-scale(
+        calc($image-size * 0.2),
+        calc($image-size * 0.3),
+        $xs-screen-width,
+        $md-screen-width
+      );
+    height:
+      linear-scale(
+        calc($image-size * 0.2),
+        calc($image-size * 0.3),
+        $xs-screen-width,
+        $md-screen-width
+      );
     color: color("black");
     font-weight: 700;
     transition: background-color 125ms linear;
@@ -101,13 +119,6 @@
 
     @media (min-width: $sm-screen-width) {
       bottom: space("lg");
-      width: calc($image-size * 0.27);
-      height: calc($image-size * 0.27);
-    }
-
-    @media (min-width: $md-screen-width) {
-      width: calc($image-size * 0.3);
-      height: calc($image-size * 0.3);
     }
 
     &--gray {
@@ -136,14 +147,12 @@
   }
 
   &__hours {
-    font-size: font-size("md");
-
-    @media (min-width: $sm-screen-width) {
-      font-size: font-size("lg");
-    }
-
-    @media (min-width: $md-screen-width) {
-      font-size: font-size("xl");
-    }
+    font-size:
+      linear-scale(
+        font-size("md"),
+        font-size("xl"),
+        $xs-screen-width,
+        $lg-screen-width
+      );
   }
 }

--- a/styles/components/_trading-card.scss
+++ b/styles/components/_trading-card.scss
@@ -1,5 +1,11 @@
 .cmp-trading-card {
-  width: $trading-card-width;
+  width:
+    linear-scale(
+      $min-trading-card-width,
+      $max-trading-card-width,
+      $xs-screen-width,
+      $lg-screen-width
+    );
   display: block;
 
   &__hrs-bar {
@@ -10,7 +16,13 @@
 
   &__name {
     display: inline-block;
-    font-size: font-size("xl");
+    font-size:
+      linear-scale(
+        font-size("md"),
+        font-size("xl"),
+        $xs-screen-width,
+        $lg-screen-width
+      );
     margin-top: space("sm");
     margin-bottom: 0;
     font-weight: 500;
@@ -22,7 +34,13 @@
 
   &__title {
     margin-top: 0;
-    font-size: font-size("md");
+    font-size:
+      linear-scale(
+        font-size("xs"),
+        font-size("md"),
+        $xs-screen-width,
+        $lg-screen-width
+      );
     font-weight: 300;
   }
 

--- a/styles/components/_week-select.scss
+++ b/styles/components/_week-select.scss
@@ -1,8 +1,4 @@
 .cmp-week-select {
-  $sm-arrow-width: 0.92rem;
-  $md-arrow-width: 1.38rem;
-  $lg-arrow-width: 2.1rem;
-
   margin: space("xl") auto space("md");
 
   @media (min-width: $lg-screen-width) {
@@ -11,19 +7,22 @@
 
   &__label {
     font-family: font-family("sans-extended");
-    font-size: font-size("lg");
+    font-size:
+      linear-scale(
+        font-size("xs"),
+        font-size("3xl"),
+        $xs-screen-width,
+        $lg-screen-width
+      );
     letter-spacing: -0.02em;
 
     @media (min-width: $sm-screen-width) {
-      font-size: font-size("xl");
-    }
-
-    @media (min-width: $md-screen-width) {
-      font-size: font-size("3xl");
+      margin: space("3xl") auto;
     }
   }
 
   &__menu {
+    padding-left: 0;
     appearance: none;
     background:
       transparent
@@ -34,11 +33,23 @@
     color: color("white");
     display: inline-block;
     font-family: font-family("sans-extended");
-    font-size: font-size("lg");
+    font-size:
+      linear-scale(
+        font-size("xs"),
+        font-size("3xl"),
+        $xs-screen-width,
+        $lg-screen-width
+      );
     font-weight: 400;
     letter-spacing: -0.02em;
     margin-top: space("2xs");
-    padding-right: $sm-arrow-width;
+    padding-right:
+      linear-scale(
+        space("md"),
+        space("lg"),
+        $xs-screen-width,
+        $md-screen-width
+      );
     position: relative;
 
     @media (min-width: $sm-screen-width) {
@@ -48,9 +59,7 @@
         no-repeat;
       background-position: right 0 top 60%;
       display: inline;
-      font-size: font-size("xl");
       margin-top: unset;
-      padding-right: $md-arrow-width;
     }
 
     @media (min-width: $md-screen-width) {
@@ -59,8 +68,10 @@
         url("data:image/svg+xml;utf8,<svg viewBox='0 0 33 19' width='33' height='19' xmlns='http://www.w3.org/2000/svg' fill='none'><path stroke='%23fff' stroke-width='2.9' d='M1.1 2 17.1 17.1M31.1 2 15 17.1'/></svg>")
         no-repeat;
       background-position: right 0 top 60%;
-      font-size: font-size("3xl");
-      padding-right: $lg-arrow-width;
+    }
+
+    &:focus {
+      @include focus-styles;
     }
   }
 

--- a/styles/settings/_variables.scss
+++ b/styles/settings/_variables.scss
@@ -2,5 +2,6 @@ $xs-screen-width: 20rem;  // 320px
 $sm-screen-width: 40rem;  // 640px
 $md-screen-width: 50.63rem;  // 810px
 $lg-screen-width: 60rem;  // 960px
-$trading-card-width: 18rem; // 288px
+$max-trading-card-width: 18rem; // 288px
+$min-trading-card-width: 6rem; // 126px
 $transition-quick: 250ms;

--- a/styles/tools/_functions.scss
+++ b/styles/tools/_functions.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 @function color($key) {
   @return map-get($colors, $key);
 }
@@ -16,4 +18,21 @@
 
 @function stringify($value) {
   @return $value + "";
+}
+
+// from sparkle
+@function strip-units($number) {
+  @return math.div($number, ($number * 0 + 1));
+}
+
+// pattern from https://css-tricks.com/linearly-scale-font-size-with-css-clamp-based-on-the-viewport/
+@function linear-scale($minSize, $maxSize, $minViewport, $maxViewport) {
+  $slope: math.div(
+    (strip-units($maxSize) - strip-units($minSize)),
+    (strip-units($maxViewport) - strip-units($minViewport))
+  );
+  $y-axis-intersection: ( - strip-units($minViewport) * $slope) + strip-units($minSize);
+  $preferred-value: calc(( $y-axis-intersection * 1rem) + ($slope * 100vw));
+
+  @return clamp($minSize, $preferred-value, $maxSize);
 }

--- a/styles/tools/functions_test.scss
+++ b/styles/tools/functions_test.scss
@@ -34,3 +34,26 @@
     @include assert-equal(stringify(6), "6");
   }
 }
+
+@include describe("strip-units function") {
+  @include it("outputs value without units") {
+    @include assert-equal(
+      strip-units(30rem),
+      30
+    );
+  }
+}
+
+@include describe("linear-scale function") {
+  @include it("returns clamp with values for linear scaling") {
+    @include assert-equal(
+      linear-scale(
+        6rem,
+        18rem,
+        20rem,
+        60rem
+      ),
+      clamp(6rem, 0rem + 30vw, 18rem)
+    );
+  }
+}


### PR DESCRIPTION
### Description

add  clamp-calc scss function to calculate linearly scaling clamp values
add linearly scaling sizing to trading cards 

### Spec

Designs: [Designs](https://www.figma.com/file/kswpPSHH2h5njVyfGDbIHk/FSA-Capstone-Project-2022?node-id=0%3A1)

See Story: [231](https://sparkbox.atlassian.net/browse/FSA22V1-231)

### Validation

* [x] This PR has visual elements, so it was reviewed by a designer. Mobile sized image has been ok'd by Jelly and number of images on a mobile screen has been ok'd from an UX point of view by Julie. 
* [x] This PR has code changes, and our linters still pass.
* [ ] This PR affects production code, so it was browser tested (see below).
* [ ] Changes are browser tested. This includes functionality, accessibility, responsiveness, and design.

#### To Validate

1. Make sure all PR Checks have passed (GitHub Actions, CircleCI, Code Climate, Snyk, etc).
2. Pull down all related branches.
3. Confirm all tests pass.
