### PR TITLE
feat: copy bio button

### DIFF
--- a/components/CopyToClipboardButton.jsx
+++ b/components/CopyToClipboardButton.jsx
@@ -1,33 +1,34 @@
-import React, {useState} from 'react'
+import React, { useState } from 'react';
 
 // Button that copies given text `content` to the users clipboard.
 // `label` and `labelCopied` are the text to display before/after click.
-const CopyToClipboardButton = ({ content, label, labelCopied }) => {
-  const [copied, setCopied] = useState(false)
+function CopyToClipboardButton({ content, label, labelCopied }) {
+  const [copied, setCopied] = useState(false);
 
   const copyContent = (e) => {
-    e.preventDefault()
-    navigator.clipboard.writeText(content)
-    setCopied(true)
+    e.preventDefault();
+    navigator.clipboard.writeText(content);
+    setCopied(true);
     setTimeout(() => {
-      setCopied(false)
-    }, 3000)
-  }
+      setCopied(false);
+    }, 3000);
+  };
 
   return (
     <button
+      type="button"
       onClick={copyContent}
       className="cmp-btn cmp-btn__link cmp-copy-to-clipboard-button"
     >
       {copied ? labelCopied : label}
     </button>
-  )
+  );
 }
 
 CopyToClipboardButton.defaultProps = {
   content: '',
   label: 'Copy Text',
-  labelCopied: 'Copied!'
-}
+  labelCopied: 'Copied!',
+};
 
-export default CopyToClipboardButton
+export default CopyToClipboardButton;

--- a/components/CopyToClipboardButton.jsx
+++ b/components/CopyToClipboardButton.jsx
@@ -1,0 +1,30 @@
+import React, {useState} from 'react'
+
+// Button that copies given text `content` to the users clipboard.
+// `label` and `labelCopied` are the text to display before/after click.
+const CopyToClipboardButton = ({ content, label, labelCopied }) => {
+  const [copied, setCopied] = useState(false)
+
+  const copyContent = (e) => {
+    e.preventDefault()
+    navigator.clipboard.writeText(content)
+    setCopied(true)
+    setTimeout(() => {
+      setCopied(false)
+    }, 3000)
+  }
+
+  return (
+    <button onClick={copyContent}>
+      {copied ? labelCopied : label}
+    </button>
+  )
+}
+
+CopyToClipboardButton.defaultProps = {
+  content: '',
+  label: 'Copy Text',
+  labelCopied: 'Copied!'
+}
+
+export default CopyToClipboardButton

--- a/components/CopyToClipboardButton.jsx
+++ b/components/CopyToClipboardButton.jsx
@@ -15,7 +15,10 @@ const CopyToClipboardButton = ({ content, label, labelCopied }) => {
   }
 
   return (
-    <button onClick={copyContent}>
+    <button
+      onClick={copyContent}
+      className="cmp-btn cmp-btn__link cmp-copy-to-clipboard-button"
+    >
       {copied ? labelCopied : label}
     </button>
   )

--- a/components/CopyToClipboardButton.jsx
+++ b/components/CopyToClipboardButton.jsx
@@ -2,11 +2,14 @@ import React, { useState } from 'react';
 
 // Button that copies given text `content` to the users clipboard.
 // `label` and `labelCopied` are the text to display before/after click.
-function CopyToClipboardButton({ content, label, labelCopied }) {
+export default function CopyToClipboardButton({
+  content = '',
+  label = 'Copy Text',
+  labelCopied = 'Copied!',
+}) {
   const [copied, setCopied] = useState(false);
 
-  const copyContent = (e) => {
-    e.preventDefault();
+  const copyContent = () => {
     navigator.clipboard.writeText(content);
     setCopied(true);
     setTimeout(() => {
@@ -18,17 +21,9 @@ function CopyToClipboardButton({ content, label, labelCopied }) {
     <button
       type="button"
       onClick={copyContent}
-      className="cmp-btn cmp-btn__link cmp-copy-to-clipboard-button"
+      className="cmp-button cmp-button--link cmp-copy-to-clipboard-button"
     >
       {copied ? labelCopied : label}
     </button>
   );
 }
-
-CopyToClipboardButton.defaultProps = {
-  content: '',
-  label: 'Copy Text',
-  labelCopied: 'Copied!',
-};
-
-export default CopyToClipboardButton;

--- a/components/PersonalBio.jsx
+++ b/components/PersonalBio.jsx
@@ -1,14 +1,18 @@
+import CopyToClipboardButton from './CopyToClipboardButton';
 import Show from './Show';
 
 export default function PersonalBio({ name, bio }) {
   return (
     <Show when={bio}>
       <section aria-labelledby="personal-bio" className="cmp-personal-bio">
-        <h3 id="personal-bio" className="cmp-personal-bio__header">
-          About
-          {' '}
-          {name}
-        </h3>
+        <div className="cmp-personal-bio__header">
+          <h3 id="personal-bio" className="cmp-personal-bio__heading">
+            About
+            {' '}
+            {name}
+          </h3>
+          <CopyToClipboardButton content={bio} label="Copy Bio" />
+        </div>
         <p className="cmp-personal-bio__content">
           {bio}
         </p>

--- a/styles/components/_button.scss
+++ b/styles/components/_button.scss
@@ -1,9 +1,9 @@
 // stub, should be fleshed out
-.cmp-btn {
+.cmp-button {
   padding: 0.25rem 1rem;
   font-size: font-size("xs");
 
-  &__link {
+  &--link {
     text-decoration: underline;
   }
 }

--- a/styles/components/_buttons.scss
+++ b/styles/components/_buttons.scss
@@ -2,6 +2,7 @@
 .cmp-btn {
   padding: 0.25rem 1rem;
   font-size: font-size("xs");
+
   &__link {
     text-decoration: underline;
   }

--- a/styles/components/_buttons.scss
+++ b/styles/components/_buttons.scss
@@ -1,0 +1,8 @@
+// stub, should be fleshed out
+.cmp-btn {
+  padding: 0.25rem 1rem;
+  font-size: font-size("xs");
+  &__link {
+    text-decoration: underline;
+  }
+}

--- a/styles/components/_copy-to-clipboard-button.scss
+++ b/styles/components/_copy-to-clipboard-button.scss
@@ -1,0 +1,8 @@
+.cmp-copy-to-clipboard-button {
+  // If this button becomes more widely used, or with variable text,
+  // then this should instead use something like :before { content: attr(data-label) }
+  // to set the width such that changing the text within the button doens't change the
+  // width of the button.
+  width: 6.25rem;
+  text-align: center;
+}

--- a/styles/components/_copy-to-clipboard-button.scss
+++ b/styles/components/_copy-to-clipboard-button.scss
@@ -3,6 +3,6 @@
   // then this should instead use something like :before { content: attr(data-label) }
   // to set the width such that changing the text within the button doens't change the
   // width of the button.
-  width: 6.25rem;
+  min-width: 6.25rem;
   text-align: center;
 }

--- a/styles/components/_personal-bio.scss
+++ b/styles/components/_personal-bio.scss
@@ -9,6 +9,11 @@
     display: flex;
     justify-content: space-between;
     align-items: baseline;
+    margin-bottom: space("md");
+
+    @media (min-width: $sm-screen-width) {
+      margin-bottom: space("lg");
+    }
   }
 
   &__heading {
@@ -17,11 +22,9 @@
     font-weight: 600;
     line-height: $header-line-height;
     margin: 0;
-    margin-bottom: space("md");
 
     @media (min-width: $sm-screen-width) {
       font-size: font-size("xl");
-      margin-bottom: space("lg");
     }
   }
 

--- a/styles/components/_personal-bio.scss
+++ b/styles/components/_personal-bio.scss
@@ -6,6 +6,12 @@
   width: 100%;
 
   &__header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+
+  &__heading {
     font-family: font-family("sans-extended");
     font-size: font-size("lg");
     font-weight: 600;

--- a/styles/elements/_button.scss
+++ b/styles/elements/_button.scss
@@ -11,12 +11,15 @@ button,
   border: 0;
   background: none;
   color: inherit;
+
   // Show the overflow in IE.
   overflow: visible;
+
   // Remove the inheritance of text transform in Edge, Firefox, and IE.
   text-transform: none;
+
   // Correct the inability to style clickable types in iOS and Safari.
-  -webkit-appearance: button;
+  appearance: button;
 
   // Buttons should be clicky.
   cursor: pointer;

--- a/styles/elements/_button.scss
+++ b/styles/elements/_button.scss
@@ -1,0 +1,23 @@
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  // Reset and normalize styles.
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: inherit;
+  // Show the overflow in IE.
+  overflow: visible;
+  // Remove the inheritance of text transform in Edge, Firefox, and IE.
+  text-transform: none;
+  // Correct the inability to style clickable types in iOS and Safari.
+  -webkit-appearance: button;
+
+  // Buttons should be clicky.
+  cursor: pointer;
+}

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -57,6 +57,7 @@
 @import "./elements/body";
 @import "./elements/a";
 @import "./elements/ul";
+@import "./elements/button";
 
 // =====================================================================
 // 5. Objects
@@ -71,6 +72,7 @@
 // 6. Components
 //    Specific UI components. This is where majority of our work takes place
 //    and our UI components are often composed of Objects and Components
+@import "./components/buttons";
 @import "./components/current-projects";
 @import "./components/fun-facts";
 @import "./components/hours-bar";

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -72,7 +72,7 @@
 // 6. Components
 //    Specific UI components. This is where majority of our work takes place
 //    and our UI components are often composed of Objects and Components
-@import "./components/buttons";
+@import "./components/button";
 @import "./components/current-projects";
 @import "./components/fun-facts";
 @import "./components/hours-bar";

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -90,6 +90,7 @@
 @import "./components/filter-toggle";
 @import "./components/fieldset-group";
 @import "./components/reset-filters";
+@import "./components/copy-to-clipboard-button";
 
 // =====================================================================
 // 7. Vendors


### PR DESCRIPTION
### Description
Button was added to bio that allows the user to click to copy the bio to the clipboard.
- Component is generic and can be used elsewhere.
- SCSS added for `button` elements and component stub `cmp-btn` as well as clipboard button specific SCSS.

### Spec

Designs: [Designs](https://www.figma.com/file/kswpPSHH2h5njVyfGDbIHk/FSA-Capstone-Project-2022?node-id=143%3A55)

See Story: [FSA22V1-241](https://sparkbox.atlassian.net/browse/FSA22V1-241)

### Validation
* [ ] This PR has visual elements, so it was reviewed by a designer.
* [ ] This PR has code changes, and our linters still pass.
* [ ] Changes are browser tested. This includes functionality, accessibility, responsiveness, and design.

#### To Validate

1. Make sure all PR Checks have passed.
2. Pull down `feat--copy-bio-button` branch.
3. Confirm all tests pass.
4. Open deploy preview and verify expected behavior on member page -- bio is copied to clipboard.
